### PR TITLE
Install JRE in launch image

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -31,7 +31,7 @@ fi
 
 export PATH="$PATH:$BP_DIR/bin"
 
-status "Installing JDK"
+status "Installing Java"
 jdk-installer -layers $1 -platform $2 -buildpack "$BP_DIR"
 
 # TODO the JVM buildpack should handle this

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,6 +1,6 @@
 [buildpack]
 id = "heroku/java"
-version = "0.11"
+version = "0.12-dev"
 name = "Java"
 
 [[stacks]]

--- a/cmd/jdk-installer/main.go
+++ b/cmd/jdk-installer/main.go
@@ -58,13 +58,13 @@ func runGoals(platformRoot, layersRoot, buildpackRoot string) error {
 		In:           []byte{},
 		Out:          os.Stdout,
 		Err:          os.Stderr,
+		Log:          log,
 		BuildpackDir: buildpackRoot,
 	}
-	jdkInstall, err := jdkInstaller.Install(appDir, layersDir)
+	_, err = jdkInstaller.Install(appDir, layersDir)
 	if err != nil {
 		return err
 	}
-	println("Java", jdkInstall.Version.Tag, "installed")
 
 	return nil
 }

--- a/jdk/integration_test.go
+++ b/jdk/integration_test.go
@@ -32,7 +32,7 @@ func testIntegrationJdk(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		wd, _ := os.Getwd()
 
-		os.Setenv("STACK", "heroku-18")
+		_ = os.Setenv("STACK", "heroku-18")
 
 		cacerts, err := ioutil.ReadFile(filepath.Join(wd, "..", "test", "fixtures", "cacerts"))
 		if err != nil {
@@ -53,7 +53,7 @@ func testIntegrationJdk(t *testing.T, when spec.G, it spec.S) {
 			t.Fatal(err)
 		}
 
-		os.Setenv("PATH", fmt.Sprintf("%s:%s", os.Getenv("PATH"), filepath.Join(wd, "..", "bin")))
+		_ = os.Setenv("PATH", fmt.Sprintf("%s:%s", os.Getenv("PATH"), filepath.Join(wd, "..", "bin")))
 
 		installer = &jdk.Installer{
 			In:           []byte{},
@@ -71,7 +71,7 @@ func testIntegrationJdk(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it.After(func() {
-		os.RemoveAll(layersDir.Root)
+		_ = os.RemoveAll(layersDir.Root)
 	})
 
 	when("#Install", func() {
@@ -102,25 +102,25 @@ func testIntegrationJdk(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal("JDBC profile.d script not installed")
 			}
 
-			var jdkMetadata jdk.Jdk
-			if err := layersDir.Layer("jdk").ReadMetadata(&jdkMetadata); err != nil {
+			var jreMetadata jdk.Jvm
+			if err := layersDir.Layer("jre").ReadMetadata(&jreMetadata); err != nil {
 				t.Fatal("Layer metadata was not written")
 			}
 
-			if jdkMetadata.Home != layersDir.Layer("jdk").Root {
-				t.Fatalf(`Jdk.Home did not match: got %s, want %s`, jdkMetadata.Home, layersDir.Layer("jdk").Root)
+			if jreMetadata.Home != layersDir.Layer("jre").Root {
+				t.Fatalf(`Jvm.Home did not match: got %s, want %s`, jreMetadata.Home, layersDir.Layer("jre").Root)
 			}
 
-			if jdkMetadata.Version.Major != 8 {
-				t.Fatalf(`Jdk.Version.Tag did not match: got %d, want %d`, jdkMetadata.Version.Major, 8)
+			if jreMetadata.Version.Major != 8 {
+				t.Fatalf(`Jvm.Version.Tag did not match: got %d, want %d`, jreMetadata.Version.Major, 8)
 			}
 
-			if jdkMetadata.Version.Tag != jdk.DefaultVersionStrings[8] {
-				t.Fatalf(`Jdk.Version.Tag did not match: got %s, want %s`, jdkMetadata.Version.Tag, jdk.DefaultVersionStrings[8])
+			if jreMetadata.Version.Tag != jdk.DefaultVersionStrings[8] {
+				t.Fatalf(`Jvm.Version.Tag did not match: got %s, want %s`, jreMetadata.Version.Tag, jdk.DefaultVersionStrings[8])
 			}
 
-			if jdkMetadata.Version.Vendor != jdk.DefaultVendor {
-				t.Fatalf(`Jdk.Version.Vendor did not match: got %s, want %s`, jdkMetadata.Version.Vendor, jdk.DefaultVendor)
+			if jreMetadata.Version.Vendor != jdk.DefaultVendor {
+				t.Fatalf(`Jvm.Version.Vendor did not match: got %s, want %s`, jreMetadata.Version.Vendor, jdk.DefaultVendor)
 			}
 		})
 
@@ -151,25 +151,25 @@ func testIntegrationJdk(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal("JDBC profile.d script not installed")
 			}
 
-			var jdkMetadata jdk.Jdk
+			var jdkMetadata jdk.Jvm
 			if err := layersDir.Layer("jdk").ReadMetadata(&jdkMetadata); err != nil {
 				t.Fatal("Layer metadata was not written")
 			}
 
 			if jdkMetadata.Home != layersDir.Layer("jdk").Root {
-				t.Fatalf(`Jdk.Home did not match: got %s, want %s`, jdkMetadata.Home, layersDir.Layer("jdk").Root)
+				t.Fatalf(`Jvm.Home did not match: got %s, want %s`, jdkMetadata.Home, layersDir.Layer("jdk").Root)
 			}
 
 			if jdkMetadata.Version.Major != 11 {
-				t.Fatalf(`Jdk.Version.Tag did not match: got %d, want %d`, jdkMetadata.Version.Major, 11)
+				t.Fatalf(`Jvm.Version.Tag did not match: got %d, want %d`, jdkMetadata.Version.Major, 11)
 			}
 
 			if jdkMetadata.Version.Tag != jdk.DefaultVersionStrings[11] {
-				t.Fatalf(`Jdk.Version.Tag did not match: got %s, want %s`, jdkMetadata.Version.Tag, jdk.DefaultVersionStrings[11])
+				t.Fatalf(`Jvm.Version.Tag did not match: got %s, want %s`, jdkMetadata.Version.Tag, jdk.DefaultVersionStrings[11])
 			}
 
 			if jdkMetadata.Version.Vendor != jdk.DefaultVendor {
-				t.Fatalf(`Jdk.Version.Vendor did not match: got %s, want %s`, jdkMetadata.Version.Vendor, jdk.DefaultVendor)
+				t.Fatalf(`Jvm.Version.Vendor did not match: got %s, want %s`, jdkMetadata.Version.Vendor, jdk.DefaultVendor)
 			}
 		})
 

--- a/jdk/integration_test.go
+++ b/jdk/integration_test.go
@@ -122,6 +122,27 @@ func testIntegrationJdk(t *testing.T, when spec.G, it spec.S) {
 			if jreMetadata.Version.Vendor != jdk.DefaultVendor {
 				t.Fatalf(`Jvm.Version.Vendor did not match: got %s, want %s`, jreMetadata.Version.Vendor, jdk.DefaultVendor)
 			}
+
+			var jdkMetadata jdk.Jvm
+			if err := layersDir.Layer("jdk").ReadMetadata(&jdkMetadata); err != nil {
+				t.Fatal("JDK Layer metadata was not written")
+			}
+
+			if jdkMetadata.Home != layersDir.Layer("jdk").Root {
+				t.Fatalf(`JDK Jvm.Home did not match: got %s, want %s`, jdkMetadata.Home, layersDir.Layer("jdk").Root)
+			}
+
+			if jdkMetadata.Version.Major != 8 {
+				t.Fatalf(`JDK Jvm.Version.Tag did not match: got %d, want %d`, jreMetadata.Version.Major, 8)
+			}
+
+			if jdkMetadata.Version.Tag != jdk.DefaultVersionStrings[8] {
+				t.Fatalf(`JDK Jvm.Version.Tag did not match: got %s, want %s`, jdkMetadata.Version.Tag, jdk.DefaultVersionStrings[8])
+			}
+
+			if jdkMetadata.Version.Vendor != jdk.DefaultVendor {
+				t.Fatalf(`JDK Jvm.Version.Vendor did not match: got %s, want %s`, jdkMetadata.Version.Vendor, jdk.DefaultVendor)
+			}
 		})
 
 		it("should install the default JDK 11", func() {

--- a/jdk/integration_test.go
+++ b/jdk/integration_test.go
@@ -111,12 +111,12 @@ func testIntegrationJdk(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf(`Jvm.Home did not match: got %s, want %s`, jreMetadata.Home, layersDir.Layer("jre").Root)
 			}
 
-			if jreMetadata.Version.Major != 8 {
-				t.Fatalf(`Jvm.Version.Tag did not match: got %d, want %d`, jreMetadata.Version.Major, 8)
+			if jreMetadata.Version.Major != "8" {
+				t.Fatalf(`Jvm.Version.Tag did not match: got %s, want %d`, jreMetadata.Version.Major, 8)
 			}
 
-			if jreMetadata.Version.Tag != jdk.DefaultVersionStrings[8] {
-				t.Fatalf(`Jvm.Version.Tag did not match: got %s, want %s`, jreMetadata.Version.Tag, jdk.DefaultVersionStrings[8])
+			if jreMetadata.Version.Tag != jdk.DefaultVersionStrings["8"] {
+				t.Fatalf(`Jvm.Version.Tag did not match: got %s, want %s`, jreMetadata.Version.Tag, jdk.DefaultVersionStrings["8"])
 			}
 
 			if jreMetadata.Version.Vendor != jdk.DefaultVendor {
@@ -132,12 +132,12 @@ func testIntegrationJdk(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf(`JDK Jvm.Home did not match: got %s, want %s`, jdkMetadata.Home, layersDir.Layer("jdk").Root)
 			}
 
-			if jdkMetadata.Version.Major != 8 {
-				t.Fatalf(`JDK Jvm.Version.Tag did not match: got %d, want %d`, jreMetadata.Version.Major, 8)
+			if jdkMetadata.Version.Major != "8" {
+				t.Fatalf(`JDK Jvm.Version.Tag did not match: got %s, want %d`, jreMetadata.Version.Major, 8)
 			}
 
-			if jdkMetadata.Version.Tag != jdk.DefaultVersionStrings[8] {
-				t.Fatalf(`JDK Jvm.Version.Tag did not match: got %s, want %s`, jdkMetadata.Version.Tag, jdk.DefaultVersionStrings[8])
+			if jdkMetadata.Version.Tag != jdk.DefaultVersionStrings["8"] {
+				t.Fatalf(`JDK Jvm.Version.Tag did not match: got %s, want %s`, jdkMetadata.Version.Tag, jdk.DefaultVersionStrings["8"])
 			}
 
 			if jdkMetadata.Version.Vendor != jdk.DefaultVendor {
@@ -181,12 +181,12 @@ func testIntegrationJdk(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf(`Jvm.Home did not match: got %s, want %s`, jdkMetadata.Home, layersDir.Layer("jdk").Root)
 			}
 
-			if jdkMetadata.Version.Major != 11 {
-				t.Fatalf(`Jvm.Version.Tag did not match: got %d, want %d`, jdkMetadata.Version.Major, 11)
+			if jdkMetadata.Version.Major != "11" {
+				t.Fatalf(`Jvm.Version.Tag did not match: got %s, want %d`, jdkMetadata.Version.Major, 11)
 			}
 
-			if jdkMetadata.Version.Tag != jdk.DefaultVersionStrings[11] {
-				t.Fatalf(`Jvm.Version.Tag did not match: got %s, want %s`, jdkMetadata.Version.Tag, jdk.DefaultVersionStrings[11])
+			if jdkMetadata.Version.Tag != jdk.DefaultVersionStrings["11"] {
+				t.Fatalf(`Jvm.Version.Tag did not match: got %s, want %s`, jdkMetadata.Version.Tag, jdk.DefaultVersionStrings["11"])
 			}
 
 			if jdkMetadata.Version.Vendor != jdk.DefaultVendor {

--- a/jdk/jdk_test.go
+++ b/jdk/jdk_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestJdk(t *testing.T) {
 	spec.Run(t, "Installer", testJdkInstaller, spec.Report(report.Terminal{}))
-	spec.Run(t, "Jdk", testJdk, spec.Report(report.Terminal{}))
+	spec.Run(t, "Jvm", testJdk, spec.Report(report.Terminal{}))
 }
 
 func testJdk(t *testing.T, when spec.G, it spec.S) {
@@ -33,12 +33,12 @@ func testJdk(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it.After(func() {
-		os.RemoveAll(layersDir.Root)
+		_ = os.RemoveAll(layersDir.Root)
 	})
 
 	when("#WriteMetadata", func() {
 		it("should detect jdk version", func() {
-			expected := jdk.Jdk{
+			expected := jdk.Jvm{
 				Home: layersDir.Root,
 				Version: jdk.Version{
 					Major:  8,
@@ -47,29 +47,29 @@ func testJdk(t *testing.T, when spec.G, it spec.S) {
 				},
 			}
 
-			if err := expected.WriteMetadata(layersDir.Layer("jdk")); err != nil {
+			if err := layersDir.Layer("jdk").WriteMetadata(expected, layers.Launch); err != nil {
 				t.Fatal(err)
 			}
 
-			var actual jdk.Jdk
+			var actual jdk.Jvm
 			if err := layersDir.Layer("jdk").ReadMetadata(&actual); err != nil {
 				t.Fatal("Layer metadata was not written")
 			}
 
 			if actual.Home != expected.Home {
-				t.Fatalf(`Jdk.Home did not match: got %s, want %s`, actual.Home, expected.Home)
+				t.Fatalf(`Jvm.Home did not match: got %s, want %s`, actual.Home, expected.Home)
 			}
 
 			if actual.Version.Major != expected.Version.Major {
-				t.Fatalf(`Jdk.Version.Tag did not match: got %d, want %d`, actual.Version.Major, expected.Version.Major)
+				t.Fatalf(`Jvm.Version.Tag did not match: got %d, want %d`, actual.Version.Major, expected.Version.Major)
 			}
 
 			if actual.Version.Tag != expected.Version.Tag {
-				t.Fatalf(`Jdk.Version.Tag did not match: got %s, want %s`, actual.Version.Tag, expected.Version.Tag)
+				t.Fatalf(`Jvm.Version.Tag did not match: got %s, want %s`, actual.Version.Tag, expected.Version.Tag)
 			}
 
 			if actual.Version.Vendor != expected.Version.Vendor {
-				t.Fatalf(`Jdk.Version.Vendor did not match: got %s, want %s`, actual.Version.Vendor, expected.Version.Vendor)
+				t.Fatalf(`Jvm.Version.Vendor did not match: got %s, want %s`, actual.Version.Vendor, expected.Version.Vendor)
 			}
 		})
 	})
@@ -83,7 +83,7 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		os.Setenv("STACK", "heroku-18")
+		_ = os.Setenv("STACK", "heroku-18")
 
 		installer = &jdk.Installer{
 			In:  []byte{},
@@ -100,7 +100,7 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it.After(func() {
-		os.RemoveAll(layersDir.Root)
+		_ = os.RemoveAll(layersDir.Root)
 	})
 
 	when("#Init", func() {

--- a/jdk/jdk_test.go
+++ b/jdk/jdk_test.go
@@ -41,7 +41,7 @@ func testJdk(t *testing.T, when spec.G, it spec.S) {
 			expected := jdk.Jvm{
 				Home: layersDir.Root,
 				Version: jdk.Version{
-					Major:  8,
+					Major:  "8",
 					Tag:    "1.8.0_191",
 					Vendor: "openjdk",
 				},
@@ -61,7 +61,7 @@ func testJdk(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			if actual.Version.Major != expected.Version.Major {
-				t.Fatalf(`Jvm.Version.Tag did not match: got %d, want %d`, actual.Version.Major, expected.Version.Major)
+				t.Fatalf(`Jvm.Version.Tag did not match: got %s, want %s`, actual.Version.Major, expected.Version.Major)
 			}
 
 			if actual.Version.Tag != expected.Version.Tag {
@@ -120,7 +120,7 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 	when("#GetVersionUrl", func() {
 		it("should get 12.0.0", func() {
 			url, err := jdk.GetVersionUrl(jdk.Version{
-				Major:  12,
+				Major:  "12",
 				Tag:    "12.0.0",
 				Vendor: "openjdk",
 			})
@@ -135,7 +135,7 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 
 		it("should get 10.0.2", func() {
 			url, err := jdk.GetVersionUrl(jdk.Version{
-				Major:  10,
+				Major:  "10",
 				Tag:    "10.0.2",
 				Vendor: "openjdk",
 			})
@@ -150,7 +150,7 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 
 		it("should get 1.8.0_181", func() {
 			url, err := jdk.GetVersionUrl(jdk.Version{
-				Major:  8,
+				Major:  "8",
 				Tag:    "1.8.0_181",
 				Vendor: "openjdk",
 			})
@@ -165,7 +165,7 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 
 		it("should get zulu-1.8.0_181", func() {
 			url, err := jdk.GetVersionUrl(jdk.Version{
-				Major:  8,
+				Major:  "8",
 				Tag:    "1.8.0_181",
 				Vendor: "zulu",
 			})
@@ -187,8 +187,8 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal(err)
 			}
 
-			if v.Major != 10 {
-				t.Fatalf(`JDK version did not match: got %d, want %d`, v.Major, 10)
+			if v.Major != "10" {
+				t.Fatalf(`JDK version did not match: got %s, want %d`, v.Major, 10)
 			}
 
 			if v.Tag != expected {
@@ -207,12 +207,12 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal(err)
 			}
 
-			if v.Major != 8 {
-				t.Fatalf(`JDK version did not match: got %d, want %d`, v.Major, 8)
+			if v.Major != "8" {
+				t.Fatalf(`JDK version did not match: got %s, want %d`, v.Major, 8)
 			}
 
-			if v.Tag != jdk.DefaultVersionStrings[8] {
-				t.Fatalf(`JDK version did not match: got %s, want %s`, v.Tag, jdk.DefaultVersionStrings[8])
+			if v.Tag != jdk.DefaultVersionStrings["8"] {
+				t.Fatalf(`JDK version did not match: got %s, want %s`, v.Tag, jdk.DefaultVersionStrings["8"])
 			}
 
 			if v.Vendor != "openjdk" {
@@ -227,12 +227,12 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal(err)
 			}
 
-			if v.Major != 11 {
-				t.Fatalf(`JDK version did not match: got %d, want %d`, v.Major, 11)
+			if v.Major != "11" {
+				t.Fatalf(`JDK version did not match: got %s, want %d`, v.Major, 11)
 			}
 
-			if v.Tag != jdk.DefaultVersionStrings[11] {
-				t.Fatalf(`JDK version did not match: got %s, want %s`, v.Tag, jdk.DefaultVersionStrings[11])
+			if v.Tag != jdk.DefaultVersionStrings["11"] {
+				t.Fatalf(`JDK version did not match: got %s, want %s`, v.Tag, jdk.DefaultVersionStrings["11"])
 			}
 
 			if v.Vendor != "openjdk" {
@@ -247,8 +247,8 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal(err)
 			}
 
-			if v.Major != 9 {
-				t.Fatalf(`JDK version did not match: got %d, want %d`, v.Major, 9)
+			if v.Major != "9" {
+				t.Fatalf(`JDK version did not match: got %s, want %d`, v.Major, 9)
 			}
 
 			if v.Tag != "9-181" {
@@ -267,8 +267,8 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal(err)
 			}
 
-			if v.Major != 8 {
-				t.Fatalf(`JDK version did not match: got %d, want %d`, v.Major, 8)
+			if v.Major != "8" {
+				t.Fatalf(`JDK version did not match: got %s, want %d`, v.Major, 8)
 			}
 
 			if v.Tag != "1.8.0_191" {
@@ -287,8 +287,8 @@ func testJdkInstaller(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal(err)
 			}
 
-			if v.Major != 8 {
-				t.Fatalf(`JDK version did not match: got %d, want %d`, v.Major, 8)
+			if v.Major != "8" {
+				t.Fatalf(`JDK version did not match: got %s, want %d`, v.Major, 8)
 			}
 
 			if v.Tag != "1.8.0_191" {


### PR DESCRIPTION
Also caches the JDK, and fixes a bug where restored metadata was converted from int to float because TOML->JSON->TOML is lossy