### PR TITLE
define [[provides]] in build plan

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -9,6 +9,13 @@ if [[ -f pom.xml ]] ||
    [[ -f pom.yaml ]] ||
    [[ -f pom.yml ]] ; then
   echo "Java"
+    cat << EOF > "$2"
+    [[provides]]
+    name = "openjdk-jre"
+
+    [[provides]]
+    name = "jvm-application"
+EOF
   exit 0
 else
   (>&2 echo "Could not find a pom.xml file! Please check that it exists and is committed to Git.")


### PR DESCRIPTION
Ensure that the buildpack defines what it provides so that other buildpacks that depend on this buildpack can specify that requirement. The reason these two were chosen was to align with the name that the riff java buildpack uses to require `openjdk-jre` and `jvm-application`.

I don't know that this is where you would want to output the `provides`. I don't know enough about the buildpack to know if it _sometimes_ provides these things and other times it does not. If you want, we could pair on this. I just wanted somewhere to have the discussion.